### PR TITLE
feat: add separate click event

### DIFF
--- a/src/core/tool.ts
+++ b/src/core/tool.ts
@@ -11,15 +11,19 @@ export default abstract class Tool {
 
   deactivate(): void {}
 
+  onMouseClick(event: KonvaEventObject<MouseEvent>): boolean {
+    return false
+  }
+
   onMouseDown(event: KonvaEventObject<MouseEvent>): boolean {
     return false
   }
 
-  onMouseUp(event: KonvaEventObject<MouseEvent>): boolean {
+  onMouseMove(event: KonvaEventObject<MouseEvent>): boolean {
     return false
   }
 
-  onMouseMove(event: KonvaEventObject<MouseEvent>): boolean {
+  onMouseUp(event: KonvaEventObject<MouseEvent>): boolean {
     return false
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,3 +25,7 @@ const globalShortcuts = new ShortcutsRegistry().put('KeyT', 'none', () => {
 })
 
 window.addEventListener('keyup', (ev) => globalShortcuts.get(ev)?.call(undefined, ev))
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+window.controller = controller

--- a/src/tools/zoom.ts
+++ b/src/tools/zoom.ts
@@ -9,7 +9,7 @@ export class ZoomTool extends Tool {
     super()
   }
 
-  onMouseUp(event: KonvaEventObject<MouseEvent>): boolean {
+  onMouseClick(event: KonvaEventObject<MouseEvent>): boolean {
     if (event.evt.ctrlKey) {
       this.resetZoom()
     } else {


### PR DESCRIPTION
Mouse up and mouse down events no longer emitted in a mouse click event.

Closes #9.